### PR TITLE
Add a custom description to the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ highlighter: rouge
 exclude:
   - README.md
 output: true
+description: SuperTux is an open-source classic 2D jump'n run sidescroller game in a style similar to the original Super Mario games.
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Adds a custom description to the site, stating `SuperTux is an open-source classic 2D jump’n run sidescroller game in a style similar to the original Super Mario games.`. This description will show when sharing a URL to the site in a social media (Discord, for example), instead of showing the repository's description.