### PR TITLE
Rename chat button to IRC

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
       <li><a href="{{ site.baseurl }}/contact.html">Contact</a></li>
     </ul>
     <ul class="menu external">
-      <li><a href="https://kiwiirc.com/nextclient/irc.libera.chat:+6697/?nick=Guest?#supertux">Chat</a></li>
+      <li><a href="ircs://irc.libera.chat/#supertux">IRC</a></li>
       <li><a href="https://github.com/SuperTux/supertux/wiki">Wiki</a></li>
       <li><a href="https://github.com/SuperTux/supertux/issues">Bugs</a></li>
       <li><a href="http://forum.freegamedev.net/viewforum.php?f=66">Forum</a></li>


### PR DESCRIPTION
We get too much spam from IRC.

I believe that most come from kids, who access the website and see a nice "chat" button.

It sounds fun, many sites have that, so why not? Oh, not a chatbot, lets close.

While a button called "IRC" will make said kids wonder "what's IRC" and click on it by curiosity, and maybe we should have a "Support" button instead, I didn't want to offend some FLOSS activists by removing it, as they would complain that Discord still has a button.