### PR TITLE
The official releases (are -> aren't) the only... (typo fix)

### DIFF
--- a/download.md
+++ b/download.md
@@ -32,7 +32,7 @@ SuperTux packages are also available in many Linux distributions.
 
 ### Other Downloads
 
-The official releases are the only available releases of SuperTux; Nightly Builds 
+The official releases aren't the only available releases of SuperTux; Nightly Builds 
 and the source code exist! You can also get SuperTux for Android!
 
 #### Nightly Builds


### PR DESCRIPTION
This sentence makes no sense the way it's written: it suggests that only the official releases are available and then goes on to list a bunch of other stuff that isn't official.

I believe it's just a typo, so I'm throwing this as a fix for it.