### PR TITLE
Add stylization for blockquotes

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -200,3 +200,10 @@ a {
     text-align: right;
     color: rgba(128, 128, 128, 1);
 }
+
+blockquote {
+    background: rgba(192, 192, 192, 0.2);
+    border-left: 0.5em solid rgba(192, 192, 192);
+    padding: 0.1em 2.5em;
+    margin-left: 0;
+}


### PR DESCRIPTION
I only feel like it looks better :)

It would be particularly helpful with #24 as it would make the block quotes more visible.

Appearance:

<img width="854" height="457" alt="Screenshot of the Other downloads section of the Downloads page, showing the block quote for the nightly instability note with a light grey background and a firmer grey left border" src="https://github.com/user-attachments/assets/a2d21202-839d-49ea-ad72-d8d4ee58e6d7" />